### PR TITLE
Returns the fallback networking method if json-ld fails to hit the cached one.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ android:
     - platform-tools
     - tools
     # The BuildTools version used by your project
-    - build-tools-25.0.3
+    - build-tools-26.0.2
     # The SDK version used to compile your project
     - android-25
     # Additional components
@@ -25,6 +25,3 @@ script:
     - ./scripts/build.sh
 after_success:
     - ./scripts/deliver.sh
-notifications:
-  slack:
-    secure: eXq25+uxkbZFqNEqQ3y+NAyIFNH0+R/hl/KCgJwemH83l7X04nyTv+1G13nHzibHIKf2OAsVM5Tqjoc9QNlWa7p7phfdzuuKH6kOXpvQCsQlxNVhT3uKyrw1/dMwKgb9ZHxxklHLQLfHZp3tqvgpUOSUaV61Wh/pQ5iysFNzhC4sFtv2nSkHbs+bkvlcRBgP3RzeDYgA1xWuxFD5m2RrH8JjsN2nGohLKPUSaThIHGc2LVnOTPNfop4UBygPY6TriTUd8vhsEaRBfF2iIrisMJFnYKUQpxhZzYGftxGAix9gZGwK5JYhg8s3Eb62v8m1CQE2EsPCdAVZRf8HmeZXbVZwxTNClyOgx7uHLt3Ily8073g2TQ9tKd/nAGDR3o+JqWFa3JWmyHXYWh09QQXzG1IMhyaF4T9Izx8FbPMcRV4oEmMvFHzYqde7XEFCukwjfjd3TYJnWblXWmCWZkDBZ1LqEzennx6EIxBpeeZ+M/CxQqNPzcU1mieQyp1klvu5kt06aDhAi/+jg6FgHtEsMqjDpKR/RXprK4j1bUgiLwxayn6vcoXzs1fb7YyIpHWVD+rTzRUEBZRz2pZJAqpaQ2mIWsQMM93aiNq6aasKRNLtpfeQm3iy/Bwpc8QGJfnBbf9cLetFOgQ2qbqjSXSHSz0/55uE+AbRAy+vwCwQL7s=

--- a/LearningMachine/app/build.gradle
+++ b/LearningMachine/app/build.gradle
@@ -176,7 +176,7 @@ dependencies {
     implementation "com.squareup.picasso:picasso:$PICASSO_VERSION"
     implementation "com.google.guava:guava:$GUAVA_VERSION"
 
-    androidTestCompile("com.android.support.test.espresso:espresso-core:$ESPRESSO_VERSION", {
+    androidTestImplementation("com.android.support.test.espresso:espresso-core:$ESPRESSO_VERSION", {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
     androidTestImplementation "org.mockito:mockito-core:$MOCKITO_VERSION"

--- a/LearningMachine/app/src/main/assets/www/jsonld.html
+++ b/LearningMachine/app/src/main/assets/www/jsonld.html
@@ -197,7 +197,7 @@
                               });
           }
           // call the underlining documentLoader using the callback API.
-          nodeDocumentLoader(url, callback);
+          return nodeDocumentLoader(url, callback);
           /* Note: By default, the node.js document loader uses a callback, but
            browser-based document loaders (xhr or jquery) return promises if they
            are supported (or polyfilled) in the browser. This behavior can be


### PR DESCRIPTION
This is the same fix I made in a few places, but had forgotten to make here. Our cached JSON-LD lookup isn't returning the base handler, so anything not cached will never return and cause verifications to hang indefinitely at step 3. 

This should fix #12 