### PR TITLE
Forces certificate titles to ellipsize at the end of one line.

### DIFF
--- a/LearningMachine/app/src/main/res/layout/list_item_certificate.xml
+++ b/LearningMachine/app/src/main/res/layout/list_item_certificate.xml
@@ -19,6 +19,9 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:text="@{viewModel.title}"
+            android:ellipsize="end"
+            android:lines="1"
+            android:maxLines="1"
             style="@style/TextStyle"/>
 
         <TextView


### PR DESCRIPTION
Fixes #10 

We force certificate titles into a single line now.