### PR TITLE
Feature/tbuehner/fix passphrase backup

### DIFF
--- a/LearningMachine/app/build.gradle
+++ b/LearningMachine/app/build.gradle
@@ -10,13 +10,13 @@ android {
         applicationId "com.learningmachine.android.app"
         minSdkVersion 19
         targetSdkVersion 30
-        versionName "3.1.8"
+        versionName "3.1.9"
         def buildNumber = System.getenv("BUILD_NUMBER")
         if (buildNumber != null) {
             versionCode buildNumber.toInteger()
             versionNameSuffix "-" + buildNumber
         } else {
-            versionCode 53
+            versionCode 55
         }
 
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'

--- a/LearningMachine/app/build.gradle
+++ b/LearningMachine/app/build.gradle
@@ -16,7 +16,7 @@ android {
             versionCode buildNumber.toInteger()
             versionNameSuffix "-" + buildNumber
         } else {
-            versionCode 55
+            versionCode 56
         }
 
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'

--- a/LearningMachine/app/src/main/java/com/learningmachine/android/app/data/bitcoin/BitcoinManager.java
+++ b/LearningMachine/app/src/main/java/com/learningmachine/android/app/data/bitcoin/BitcoinManager.java
@@ -152,7 +152,6 @@ public class BitcoinManager {
     public void resetEverything() {
         mIssuerStore.reset();
         mCertificateStore.reset();
-        mPassphraseManager.reset();
     }
 
     public Observable<Wallet> setPassphrase(String newPassphrase) {

--- a/LearningMachine/app/src/main/java/com/learningmachine/android/app/data/preferences/SharedPreferencesManager.java
+++ b/LearningMachine/app/src/main/java/com/learningmachine/android/app/data/preferences/SharedPreferencesManager.java
@@ -18,8 +18,6 @@ public class SharedPreferencesManager {
 
     private static final String PREF_LAST_LOG_DELETED_TIMESTAMP = "SharedPreferencesManager.Logs.LogsDeletedTimestamp";
 
-    private static final String PREF_SKIP_MIGRATION = "SharedPreferencesManager.SkipMigration";
-
     private SharedPreferences mPrefs;
 
     public SharedPreferencesManager(Context context) {
@@ -103,15 +101,5 @@ public class SharedPreferencesManager {
 
     public long getLastLogDeletedTimestamp() {
         return mPrefs.getLong(PREF_LAST_LOG_DELETED_TIMESTAMP, 0);
-    }
-
-    public boolean shouldSkipMigration() {
-        return mPrefs.getBoolean(PREF_SKIP_MIGRATION, false);
-    }
-
-    public void setSkipMigration(boolean skip) {
-        mPrefs.edit()
-                .putBoolean(PREF_SKIP_MIGRATION, skip)
-                .apply();
     }
 }

--- a/LearningMachine/app/src/main/java/com/learningmachine/android/app/ui/onboarding/BackupPassphraseFragment.java
+++ b/LearningMachine/app/src/main/java/com/learningmachine/android/app/ui/onboarding/BackupPassphraseFragment.java
@@ -120,7 +120,7 @@ public class BackupPassphraseFragment extends OnboardingFragment {
     protected void onSave() {
         ((OnboardingActivity)getActivity()).askToSavePassphraseToDevice(mPassphrase, (passphrase) -> {
             if(passphrase == null) {
-                if(Build.VERSION.SDK_INT >= 30) {
+                if(Build.VERSION.SDK_INT >= 23) {
                     return;
                 }
                 DialogUtils.showAlertDialog(getContext(), this,

--- a/LearningMachine/app/src/main/java/com/learningmachine/android/app/ui/onboarding/PastePassphraseFragment.java
+++ b/LearningMachine/app/src/main/java/com/learningmachine/android/app/ui/onboarding/PastePassphraseFragment.java
@@ -53,7 +53,7 @@ public class PastePassphraseFragment extends OnboardingFragment {
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         mBinding = DataBindingUtil.inflate(inflater, R.layout.fragment_paste_passphrase, container, false);
 
-        if (Build.VERSION.SDK_INT >= 30) {
+        if (Build.VERSION.SDK_INT >= 23) {
             mBinding.chooseBackupFileButton.setVisibility(View.VISIBLE);
             mBinding.chooseBackupFileButton.setOnClickListener(view -> retrievePassphraseFromDevice());
         } else {

--- a/LearningMachine/app/src/main/java/com/learningmachine/android/app/ui/settings/SettingsFragment.java
+++ b/LearningMachine/app/src/main/java/com/learningmachine/android/app/ui/settings/SettingsFragment.java
@@ -45,7 +45,6 @@ public class SettingsFragment extends LMFragment {
     private static final int REQUEST_OPEN = 201;
 
     @Inject protected BitcoinManager mBitcoinManager;
-    @Inject protected PassphraseManager mPassphraseManager;
 
     public static SettingsFragment newInstance() {
         return new SettingsFragment();
@@ -176,20 +175,6 @@ public class SettingsFragment extends LMFragment {
                 }
                 return null;
             };
-            if (Build.VERSION.SDK_INT >= 30) {
-                message = getResources().getString(R.string.settings_logout_message);
-                callback = (btnIdx) -> {
-                    if(btnIdx == 1) {
-                        Intent openIntent = new Intent(Intent.ACTION_OPEN_DOCUMENT);
-                        openIntent.addCategory(Intent.CATEGORY_OPENABLE);
-                        openIntent.addFlags(FLAG_GRANT_READ_URI_PERMISSION | FLAG_GRANT_WRITE_URI_PERMISSION);
-                        openIntent.setType("application/octet-stream");
-                        openIntent.putExtra(Intent.EXTRA_TITLE, "learningmachine.dat");
-                        startActivityForResult(openIntent, REQUEST_OPEN);
-                    }
-                    return null;
-                };
-            }
 
             DialogUtils.showAlertDialog(getContext(), this,
                     R.drawable.ic_dialog_failure,
@@ -199,20 +184,6 @@ public class SettingsFragment extends LMFragment {
                     getResources().getString(R.string.onboarding_passphrase_cancel),
                     callback);
         });
-    }
-
-    @Override
-    public void onActivityResult(int requestCode, int resultCode, Intent data) {
-        if (requestCode == REQUEST_OPEN) {
-            if (Build.VERSION.SDK_INT >= 30 && resultCode == RESULT_OK) {
-                mPassphraseManager.deletePassphrase(data.getData());
-            }
-            mBitcoinManager.resetEverything();
-
-            Intent intent = new Intent(getActivity(), OnboardingActivity.class);
-            startActivity(intent);
-            getActivity().finish();
-        }
     }
 }
 

--- a/LearningMachine/app/src/main/java/com/learningmachine/android/app/ui/settings/passphrase/RevealPassphraseFragment.java
+++ b/LearningMachine/app/src/main/java/com/learningmachine/android/app/ui/settings/passphrase/RevealPassphraseFragment.java
@@ -83,7 +83,7 @@ public class RevealPassphraseFragment extends LMFragment {
     protected void onSave() {
         ((LMActivity)getActivity()).askToSavePassphraseToDevice(mPassphrase, (passphrase) -> {
             if(passphrase == null) {
-                if(Build.VERSION.SDK_INT >= 30) {
+                if(Build.VERSION.SDK_INT >= 23) {
                     return;
                 }
                 DialogUtils.showAlertDialog(getContext(), this,

--- a/LearningMachine/app/src/main/java/com/learningmachine/android/app/ui/splash/SplashActivity.java
+++ b/LearningMachine/app/src/main/java/com/learningmachine/android/app/ui/splash/SplashActivity.java
@@ -29,91 +29,14 @@ import static com.learningmachine.android.app.data.url.LaunchType.ADD_ISSUER;
 public class SplashActivity extends LMActivity {
 
     @Inject protected SharedPreferencesManager mSharedPreferencesManager;
-    @Inject protected BitcoinManager mBitcoinManager;
-    @Inject protected PassphraseManager mPassphraseManager;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         Injector.obtain(this)
                 .inject(this);
-        if (Build.VERSION.SDK_INT >= 30 && mPassphraseManager.doesLegacyPassphraseFileExist() &&
-                !mSharedPreferencesManager.shouldSkipMigration()) {
-            movePassphraseBackup();
-        } else {
-            launch();
-        }
-    }
 
-    private void movePassphraseBackup() {
-        FragmentManager fragmentManager = getSupportFragmentManager();
-        AlertDialogFragment alertDialogFragment = AlertDialogFragment.newInstance(
-                false,
-                0,
-                R.drawable.ic_backup_passphrase,
-                getResources().getString(R.string.migrate_passphrase_title),
-                getResources().getString(R.string.migrate_passphrase_message),
-                getResources().getString(R.string.migrate_passphrase_move),
-                getResources().getString(R.string.migrate_passphrase_delete),
-                (btnIdx) -> {
-                    migratePassphrase((passphrase) -> {
-                        if (passphrase != null) {
-                            launch();
-                        } else {
-                            migrationFailed();
-                        }
-                    });
-                    return null;
-                },
-                null,
-                (cancel) -> {
-                    confirmDelete();
-                    return null;
-                });
-        alertDialogFragment.show(fragmentManager, "PassphraseMigrationAlert");
-    }
-
-    private void confirmDelete() {
-        FragmentManager fragmentManager = getSupportFragmentManager();
-        AlertDialogFragment alertDialogFragment = AlertDialogFragment.newInstance(
-                false,
-                0,
-                R.drawable.ic_dialog_warning,
-                getResources().getString(R.string.delete_backup_title),
-                getResources().getString(R.string.delete_backup_message),
-                getResources().getString(R.string.dialog_confirm),
-                getResources().getString(R.string.dialog_cancel),
-                (btnIdx) -> {
-                    mPassphraseManager.deleteLegacyPassphrase();
-                    launch();
-                    return null;
-                },
-                null,
-                (cancel) -> {
-                    movePassphraseBackup();
-                    return null;
-                });
-        alertDialogFragment.show(fragmentManager, "PassphraseMigrationAlert");
-    }
-
-    private void migrationFailed() {
-        FragmentManager fragmentManager = getSupportFragmentManager();
-        AlertDialogFragment alertDialogFragment = AlertDialogFragment.newInstance(
-                false,
-                0,
-                R.drawable.ic_dialog_warning,
-                getResources().getString(R.string.migration_failed_title),
-                getResources().getString(R.string.migration_failed_message),
-                getResources().getString(R.string.ok_button),
-                null,
-                (btnIdx) -> {
-                    mSharedPreferencesManager.setSkipMigration(true);
-                    launch();
-                    return null;
-                },
-                null,
-                null);
-        alertDialogFragment.show(fragmentManager, "PassphraseMigrationAlert");
+        launch();
     }
 
     private void launch() {

--- a/LearningMachine/app/src/main/res/values-es/strings.xml
+++ b/LearningMachine/app/src/main/res/values-es/strings.xml
@@ -164,15 +164,9 @@
     <!--SAML login title-->
     <string name="login_to_issuer">Iniciar sesión en el emisor</string>
     <string name="onboarding_paste_passphrase_choose_backup_button">Seleccionar archivo de copia de seguridad...</string>
-    <string name="migration_failed_message">Error al mover el archivo de copia de seguridad de frase de contraseña. Mueva manualmente el archivo learningmachine.dat a la carpeta de descargas.</string>
-    <string name="migration_failed_title">Error de migración</string>
     <string name="dialog_cancel">Cancelar</string>
     <string name="dialog_confirm">Confirmar eliminación</string>
     <string name="delete_backup_message">¿Está seguro que desea eliminar su copia de seguridad de frase de contraseña\? Esta acción no se puede deshacer.</string>
     <string name="delete_backup_title">Eliminar copia de seguridad</string>
-    <string name="migrate_passphrase_delete">Eliminar</string>
-    <string name="migrate_passphrase_move">Mover</string>
-    <string name="migrate_passphrase_message">Los permisos de archivo de Android han cambiado. Su archivo de copia de seguridad de frase de contraseña debe ser movido a otra ubicación.</string>
-    <string name="migrate_passphrase_title">Mover copia de seguridad de frase de contraseña</string>
     <string name="settings_logout_message">Cerrar sesión removerá todas sus credenciales. Debe eliminar cualquier frase de contraseñaen este dispositivo.</string>
 </resources>

--- a/LearningMachine/app/src/main/res/values-it/strings.xml
+++ b/LearningMachine/app/src/main/res/values-it/strings.xml
@@ -162,15 +162,9 @@
     <!--SAML login title-->
     <string name="login_to_issuer">Accedi all\'emittente</string>
     <string name="settings_logout_message">Il disconnettersi rimuoverà tutte le tue credenziali. È necessario eliminare tutte le passphrase memorizzate su questo dispositivo.</string>
-    <string name="migrate_passphrase_message">I permessi dei file Android sono cambiati. Il tuo file di backup della passphrase deve essere spostato in un\'altra posizione.</string>
-    <string name="migrate_passphrase_title">Spostare il backup della passphrase</string>
-    <string name="migrate_passphrase_move">Sposta</string>
-    <string name="migrate_passphrase_delete">Elimina</string>
     <string name="delete_backup_title">Elimina Backup</string>
     <string name="delete_backup_message">Sei sicuro di voler eliminare il backup della passphrase\? Questa azione non può essere annullata.</string>
     <string name="dialog_confirm">Conferma eliminazione</string>
     <string name="dialog_cancel">Annulla</string>
-    <string name="migration_failed_message">Impossibile spostare il file di backup della passphrase. Per favore sposta manualmente il file learningmachine.dat nella cartella dei download.</string>
-    <string name="migration_failed_title">Migrazione non riuscita</string>
     <string name="onboarding_paste_passphrase_choose_backup_button">Scegli file di Backup...</string>
 </resources>

--- a/LearningMachine/app/src/main/res/values-ja/strings.xml
+++ b/LearningMachine/app/src/main/res/values-ja/strings.xml
@@ -160,15 +160,9 @@
     <!--SAML login title-->
     <string name="login_to_issuer">発行者にログイン</string>
     <string name="onboarding_paste_passphrase_choose_backup_button">バックアップファイルを選択...</string>
-    <string name="migration_failed_message">パスフレーズバックアップファイルの移動に失敗しました。learningmachine.datファイルをダウンロードフォルダに手動で移動してください。</string>
-    <string name="migration_failed_title">移行に失敗しました</string>
     <string name="dialog_cancel">キャンセル</string>
     <string name="dialog_confirm">削除の確認</string>
     <string name="delete_backup_message">パスフレーズバックアップを削除しますか？このアクションを元に戻すことはできません。</string>
     <string name="delete_backup_title">バックアップを削除</string>
-    <string name="migrate_passphrase_delete">削除</string>
-    <string name="migrate_passphrase_move">移動</string>
-    <string name="migrate_passphrase_message">Androidファイルパーミッションが変更されました。パスフレーズバックアップファイルを別の場所に移動する必要があります。</string>
-    <string name="migrate_passphrase_title">パスフレーズのバックアップを移動</string>
     <string name="settings_logout_message">ログアウトすると、すべての資格情報が削除されます。このデバイスに保存されているパスフレーズを削除する必要があります。</string>
 </resources>

--- a/LearningMachine/app/src/main/res/values-mt/strings.xml
+++ b/LearningMachine/app/src/main/res/values-mt/strings.xml
@@ -166,15 +166,9 @@
     <!--SAML login title-->
     <string name="login_to_issuer">Idħol</string>
     <string name="settings_logout_message">Jekk tillogja barra l-kredenzjali tiegħek jiġu mneħija. Għandek tħassar kull passphrase maħzuna fuq dan iit-tagħmir.</string>
-    <string name="migrate_passphrase_title">Ressaq il-passphrase backup</string>
-    <string name="migrate_passphrase_message">Il-permessi tal-Android fajl ġew mibdula. Il-passphrase backup file irid jiġi mressaq f\'post ieħor.</string>
-    <string name="migrate_passphrase_move">Ressaq</string>
-    <string name="migrate_passphrase_delete">Ħassar</string>
     <string name="delete_backup_title">Ħassar il-backup</string>
     <string name="delete_backup_message">Ċert il trid tħassar il-passphrase backup tiegħek\? Din l-azzjoni ma tistax tiġi revokata.</string>
     <string name="dialog_confirm">Ikkonferma li trid tħassar</string>
     <string name="dialog_cancel">Ikkanċella</string>
-    <string name="migration_failed_title">Il-migrazzjoni ma rnexxitx</string>
-    <string name="migration_failed_message">Ma rnexxilekx tressaq il-fajl tal-passphrase backup. Jekk jogħġbok ressaq il-fajl learningmachine.dat b\'mod manwali fid-downloads folder.</string>
     <string name="onboarding_paste_passphrase_choose_backup_button">Agħżel il-file tal-backup.</string>
 </resources>

--- a/LearningMachine/app/src/main/res/values/strings.xml
+++ b/LearningMachine/app/src/main/res/values/strings.xml
@@ -230,19 +230,11 @@
     <!--SAML login title-->
     <string name="login_to_issuer">Log In To Issuer</string>
 
-    <!--Migrate Passphrase-->
-    <string name="migrate_passphrase_title">Move Passphrase Backup</string>
-    <string name="migrate_passphrase_message">Android file permissions have changed.  Your passphrase backup file must be moved to another location.</string>
-    <string name="migrate_passphrase_move">Move</string>
-    <string name="migrate_passphrase_delete">Delete</string>
-
     <!--Delete Backup-->
     <string name="delete_backup_title">Delete Backup</string>
     <string name="delete_backup_message">Are you sure you want to delete your passphrase backup?  This action cannot be undone.</string>
     <string name="dialog_confirm">Confirm Delete</string>
     <string name="dialog_cancel">Cancel</string>
-    <string name="migration_failed_title">Migration Failed</string>
-    <string name="migration_failed_message">Failed to move passphrase backup file.  Please manually move the learningmachine.dat file to the downloads folder.</string>
     <string name="onboarding_paste_passphrase_choose_backup_button">Choose Backup File...</string>
 
 </resources>


### PR DESCRIPTION
This removes the passphrase migration and fixes the passphrase backups.  Users will be able to select the passphrase backup (learningmachine.dat) file from their device themselves in Android 11+.  For Android 6.0+, we'll do our best to access what was previously the default storage location for learningmachine.dat.  If we can't access it programmatically, then we'll prompt the user to select the backup file themselves from the device.  For Android <6.0, we'll always access the default location, and the user won't be prompted to choose the file.