### PR TITLE
Correct link to RxLint

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ Paste in this android project at this location: `wallet-android/LearningMachine/
 * Automatically complete sequences based on a second lifecycle stream
 * Apache 2.0
 
-### [RxLint](https://bitbucket.org/littlerobots/rxlint)
+### [RxLint](https://github.com/littlerobots/rxlint)
 
 * A set of lint checks that check your RxJava code
 * Apache 2.0


### PR DESCRIPTION
I was reading the docs and found a dead link.
RxLint had moved from Bitbucket to Github.