### PR TITLE
Remove Multidex declaration

### DIFF
--- a/LearningMachine/app/build.gradle
+++ b/LearningMachine/app/build.gradle
@@ -20,7 +20,6 @@ android {
         }
 
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
-        multiDexEnabled true
     }
 
     compileOptions {
@@ -67,9 +66,6 @@ android {
             if (project.hasProperty("devBuild")) {
                 // don't package all resources for dev builds
                 resConfigs("en", "xxhdpi")
-
-                // avoid legacy multidex
-                minSdkVersion 21
             }
         }
         staging {
@@ -118,7 +114,6 @@ android {
 }
 
 final SUPPORT_VERSION = '27.1.1'
-final MULTIDEX_VERSION = '1.0.1'
 final DAGGER_VERSION = '2.22.1'
 final SLF4J_VERSION = '1.7.25'
 final SPONGYCASTLE_VERSION = '1.56.0.0'
@@ -169,7 +164,6 @@ dependencies {
     implementation 'androidx.recyclerview:recyclerview:1.0.0'
     implementation 'androidx.cardview:cardview:1.0.0'
     implementation 'com.google.android.material:material:1.0.0'
-    implementation 'androidx.multidex:multidex:2.0.0'
     implementation "org.slf4j:slf4j-log4j12:$SLF4J_VERSION"
     implementation "com.madgag.spongycastle:core:$SPONGYCASTLE_VERSION"
     implementation "com.google.protobuf:protobuf-java:$PROTOBUF_VERSION"
@@ -213,7 +207,6 @@ dependencies {
     testImplementation "org.json:json:20140107"
     testImplementation "org.mockito:mockito-core:$MOCKITO_VERSION"
     testImplementation "org.robolectric:robolectric:$ROBOLECTRIC_VERSION"
-    testImplementation "org.robolectric:shadows-multidex:$ROBOLECTRIC_VERSION"
     testImplementation "joda-time:joda-time:$JODATIME_VERSION"
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
 }

--- a/LearningMachine/app/src/main/java/com/learningmachine/android/app/LMApplication.java
+++ b/LearningMachine/app/src/main/java/com/learningmachine/android/app/LMApplication.java
@@ -1,12 +1,12 @@
 package com.learningmachine.android.app;
 
+import android.app.Application;
 import android.content.Context;
 import android.content.pm.ApplicationInfo;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
 import android.os.Build;
 import androidx.annotation.NonNull;
-import androidx.multidex.MultiDexApplication;
 import android.webkit.WebView;
 
 import com.learningmachine.android.app.data.CertificateManager;
@@ -27,7 +27,7 @@ import javax.inject.Inject;
 
 import timber.log.Timber;
 
-public class LMApplication extends MultiDexApplication {
+public class LMApplication extends Application {
 
     protected LMGraph mGraph;
 


### PR DESCRIPTION
Since the min SDK is 31, it is no longer necessary to use the Multidex library.

See the following for more info: https://developer.android.com/build/multidex#mdex-on-l