### PR TITLE
Update to ExoPlayer 2.13.3

### DIFF
--- a/LearningMachine/app/build.gradle
+++ b/LearningMachine/app/build.gradle
@@ -185,8 +185,7 @@ dependencies {
     implementation "com.squareup.picasso:picasso:$PICASSO_VERSION"
     implementation "com.google.guava:guava:$GUAVA_VERSION"
 
-    implementation 'com.google.android.exoplayer:exoplayer:2.8.4'
-
+    implementation 'com.google.android.exoplayer:exoplayer:2.13.3'
 
     androidTestImplementation('androidx.test.espresso:espresso-core:3.1.0', {
         exclude group: 'com.android.support', module: 'support-annotations'


### PR DESCRIPTION
This commit updates ExoPlayer to the earliest version available on [Google's Maven repository](https://maven.google.com/). This is to make the CI pass again.

> [!WARNING]
>
>️ This is not the latest version of ExoPlayer, to limit the risk of breaking changes.
> In any case, ExoPlayer is deprecated and should be replaced with AndroidX Media3.

**Note:** it looks like the only file using ExoPlayer (`fragment_video.xml`) is not used, so maybe ExoPlayer could be removed completely?